### PR TITLE
Fix if/else matching for only-profile input

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Configure AWS Credential Profiles for GitHub Actions
 
-The primary reason this action exists is to address using multiple profiles at the same time in GitHub Actions. The [official action](https://github.com/marketplace/actions/configure-aws-credentials-action-for-github-actions) is not sufficient for multiple account usage as it only sets one set of AWS environment variables at a time. Trying to reuse the action simply overwrites the environment variables with the new credentials.
+Drop-in replacement for aws-actions/configure-aws-credentials with additional features to configure multiple AWS roles as AWS profiles.
+
+The primary reason this action exists is to address using multiple AWS Roles at the same time in GitHub Actions. The [official action](https://github.com/marketplace/actions/configure-aws-credentials-action-for-github-actions) is not sufficient for multiple account usage as it only sets one set of AWS environment variables at a time. Trying to reuse the action simply overwrites the environment variables with the new credentials.
 
 This action uses the official `aws-actions/configure-aws-credentials@v4` under the hood. Almost all inputs of the original action are supported. The main difference is that the `profile` input is required. This action will create the `~/.aws/config` and `~/.aws/credentials` files with the specified profile name (can be overridden with `AWS_CONFIG_FILE` & `AWS_SHARED_CREDENTIALS_FILE`, details below).
 
@@ -11,8 +13,8 @@ The below inputs are in additional to the [official action inputs](https://githu
 
 | Input Name   | Description                                                                     | Required | default values |
 | :----------- | :------------------------------------------------------------------------------ | :------: | :------------: |
-| profile      | Name of the profile to be created                                               |  `true`  |    default     |
-| only-profile | This will unset the AWS env vars to empty string. Necessary for using profiles  | `false`  |     `true`     |
+| profile      | Name of the profile to be created                                               | `false`  |    default     |
+| only-profile | This will unset the AWS env vars to empty string. Necessary for using profiles  | `false`  |    `false`     |
 | whoami       | Run additional `aws sts get-caller-identity` to check if the profile is working |  `true`  |    `false`     |
 
 # Unsupported Inputs

--- a/action.yml
+++ b/action.yml
@@ -1,6 +1,6 @@
 name: Configure Multiple AWS Roles
 
-description: Configures an OIDC AWS Role Session as an aws config profile.
+description: Drop-in replacement for aws-actions/configure-aws-credentials with additional features to configure multiple AWS roles as AWS profiles.
 
 branding:
   icon: "cloud"
@@ -9,12 +9,12 @@ branding:
 inputs:
   # Additional inputs vs aws-actions/configure-aws-credentials@v4
   profile:
-    required: true
+    required: false
     description: Name of profile to be created
     default: "default"
   only-profile:
     description: Whether to unset credentials in the environment after writing to the profile. May be useful if you run this action multiple times in the same job
-    default: "true"
+    default: "false"
     required: false
   whoami:
     description: Whether to run `aws sts get-caller-identity` after configuring the profile
@@ -71,6 +71,9 @@ inputs:
   managed-session-policies:
     description: Define a list of managed session policies to use when assuming a role
     required: false
+  # output-credentials:
+  #   description: Whether to set credentials as step output
+  #   required: false
   unset-current-credentials:
     description: Whether to unset the existing credentials in your runner. May be useful if you run this action multiple times in the same job
     required: false
@@ -156,7 +159,7 @@ runs:
     # We cannot unset the variables due to https://github.com/actions/runner/issues/1126, but we can set them to fake values to prevent accidental use
     - name: Set AWS Environment Variables to fake values
       id: unset-env-vars
-      if: inputs.only-profile
+      if: ${{ inputs.only-profile == 'true' }}
       shell: bash
       run: |
         echo "Setting dummy AWS Environment Variables"
@@ -166,7 +169,7 @@ runs:
 
     - name: Check Who Am I
       id: whoami
-      if: inputs.whoami
+      if: ${{ inputs.whoami == 'true' }}
       shell: bash
       run: |
         aws sts --profile ${{ inputs.profile }} get-caller-identity


### PR DESCRIPTION
Github Actions only supports string as input type. Also note that for matching it has to be quoted in single quotes, like 'false'

fixes #9