### PR TITLE
fix(actions): Pin aws-actions/configure-aws-credentials to full SHA

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -111,7 +111,7 @@ runs:
   steps:
     - name: Get AWS Credentials
       id: aws-credentials
-      uses: aws-actions/configure-aws-credentials@v6
+      uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
       with:
         output-credentials: true
 


### PR DESCRIPTION
Pin the internal aws-actions/configure-aws-credentials reference from the unpinned @v6 tag to the full commit SHA
8df5847569e6427dd6c4fb1cf565c83acfa8afa7 (v6.0.0).

This creates a stronger security posture, especially with the recent supply chain attacks on GitHub Actions